### PR TITLE
App tests - fix "is not known element/properties" errors

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
@@ -15,6 +16,7 @@ describe('AppComponent', () => {
         LayoutComponent,
         LandingPageComponent
       ],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });
 

--- a/src/app/landing-page/customers-stories/customer-story/customer-story.component.spec.ts
+++ b/src/app/landing-page/customers-stories/customer-story/customer-story.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { CustomerImageComponent } from './customer-image/customer-image.component';
@@ -11,6 +12,7 @@ describe('CustomerStoryComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [CustomerStoryComponent, CustomerImageComponent],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CustomerStoryComponent);

--- a/src/app/landing-page/customers-stories/customers-stories.component.spec.ts
+++ b/src/app/landing-page/customers-stories/customers-stories.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CustomerStoryComponent } from './customer-story/customer-story.component';
 
@@ -10,6 +11,7 @@ describe('CustomersStoriesComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [CustomersStoriesComponent, CustomerStoryComponent],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CustomersStoriesComponent);

--- a/src/app/landing-page/landing-page.component.spec.ts
+++ b/src/app/landing-page/landing-page.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CompanyValuesComponent } from './company-values/company-values.component';
 import { CustomersStoriesComponent } from './customers-stories/customers-stories.component';
@@ -19,6 +20,7 @@ describe('LandingPageComponent', () => {
         CustomersStoriesComponent,
         QueriesComponent,
       ],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(LandingPageComponent);

--- a/src/app/landing-page/queries/queries.component.spec.ts
+++ b/src/app/landing-page/queries/queries.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { QueriesComponent } from './queries.component';
@@ -10,6 +11,7 @@ describe('QueriesComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [QueriesComponent, QueryButtonComponent],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(QueriesComponent);

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { By } from '@angular/platform-browser';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 import { HeaderComponent } from './header.component';
 
@@ -12,6 +13,7 @@ describe('HeaderComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [HeaderComponent],
       imports: [MatIconModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
@@ -96,8 +98,12 @@ describe('HeaderComponent', () => {
     component.width = 500;
     component.height = 500;
     fixture.detectChanges();
-    expect(component.querySelector(".header__content--toggle__burger")).not.toBeNull();
-    expect(component.querySelector(".header__content--toggle__close")).toBeNull();
+    expect(
+      component.querySelector('.header__content--toggle__burger')
+    ).not.toBeNull();
+    expect(
+      component.querySelector('.header__content--toggle__close')
+    ).toBeNull();
   });
 
   it('should render close icon when menu is open (small screen)', () => {
@@ -106,7 +112,11 @@ describe('HeaderComponent', () => {
     component.width = 500;
     component.height = 500;
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('.header__content--toggle__burger'))).toBeNull();
-    expect(fixture.debugElement.query(By.css('.header__content--toggle__close'))).not.toBeNull();
+    expect(
+      fixture.debugElement.query(By.css('.header__content--toggle__burger'))
+    ).toBeNull();
+    expect(
+      fixture.debugElement.query(By.css('.header__content--toggle__close'))
+    ).not.toBeNull();
   });
 });

--- a/src/app/layout/layout.component.spec.ts
+++ b/src/app/layout/layout.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FooterComponent } from './footer/footer.component';
 import { HeaderComponent } from './header/header.component';
@@ -11,6 +12,7 @@ describe('LayoutComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [LayoutComponent, HeaderComponent, FooterComponent],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(LayoutComponent);


### PR DESCRIPTION
Fix (surpress) "is not known element/properties" errors in layout and landing page components by adding NO_ERRORS_SCHEMA